### PR TITLE
Handle ObjectRemoved:Delete events and translate those into Delta table removals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.4"
+version = "0.9.0"
 edition = "2021"
 keywords = ["deltalake", "parquet", "lambda", "delta"]
 homepage = "https://github.com/buoyant-data/oxbow"

--- a/deployment/simple.tf
+++ b/deployment/simple.tf
@@ -9,7 +9,7 @@ resource "aws_s3_bucket_notification" "bucket-notifications" {
 
   queue {
     queue_arn     = aws_sqs_queue.oxbow.arn
-    events        = ["s3:ObjectCreated:*"]
+    events        = ["s3:ObjectCreated:*", "s3:ObjectRemoved:Delete"]
     filter_suffix = ".parquet"
   }
 


### PR DESCRIPTION
This change will handle deleted files correctly, but will also ensure that removed files don't incorrectly show up as additions.

With this change S3 LifeCycle configurations should _just work_ with Delta tables

Fixes #10