### PR TITLE
Introduce UNWRAP_SNS_ENVELOPE which allows SNS to be introduced upstream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.8.5"
+version = "0.9.0"
 edition = "2021"
 keywords = ["deltalake", "parquet", "lambda", "delta"]
 homepage = "https://github.com/buoyant-data/oxbow"
@@ -17,7 +17,7 @@ license-file = "LICENSE.txt"
 
 [workspace.dependencies]
 anyhow = "=1"
-aws_lambda_events = { version = "0.12.0", default-features = false, features = ["sqs", "s3"] }
+aws_lambda_events = { version = "0.12.0", default-features = false, features = ["sns", "sqs", "s3"] }
 deltalake = { version = "0.16.5", features = ["s3", "json"]}
 tokio = { version = "=1", features = ["macros"] }
 serde_json = "1"

--- a/crates/oxbow-lambda-shared/Cargo.toml
+++ b/crates/oxbow-lambda-shared/Cargo.toml
@@ -15,4 +15,5 @@ deltalake = { workspace = true }
 chrono = "0.4.31"
 serde = { version = "=1", features = ["rc"] }
 serde_json = "=1"
+tracing = { workspace = true }
 urlencoding = "=2"

--- a/crates/oxbow/src/lib.rs
+++ b/crates/oxbow/src/lib.rs
@@ -763,7 +763,7 @@ mod tests {
 
         let mut uniq = HashSet::new();
         for field in &fields {
-            uniq.insert(field.clone());
+            uniq.insert(field);
         }
         assert_eq!(
             uniq.len(),

--- a/lambdas/auto-tag/src/main.rs
+++ b/lambdas/auto-tag/src/main.rs
@@ -14,7 +14,10 @@ async fn function_handler(event: LambdaEvent<SqsEvent>) -> Result<(), Error> {
     let client = aws_sdk_s3::Client::new(&config);
 
     debug!("Receiving event: {:?}", event);
-    let records = s3_from_sqs(event.payload)?;
+    let records = match std::env::var("UNWRAP_SNS_ENVELOPE") {
+        Ok(_) => s3_from_sns(event.payload)?,
+        Err(_) => s3_from_sqs(event.payload)?,
+    };
     let extensions = extensions_for(&records);
 
     for (locator, tag) in extensions.iter() {

--- a/lambdas/oxbow/README.adoc
+++ b/lambdas/oxbow/README.adoc
@@ -1,0 +1,31 @@
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+:toc: macro
+
+= Oxbow Lambda
+
+The Oxbow lambda handles modifying append only Delta tables
+
+toc::[]
+
+== Environment Variables
+
+|===
+
+| Name | Default Value | Notes
+
+| `RUST_LOG`
+| `error`
+| Set the log level, e.g. `info`, `warn`, `error`. Can be scoped to specific modules, i.e. `oxbow=debug`
+
+| `UNWRAP_SNS_ENVELOPE`
+| _null_
+| Should only be used if S3 Event Notifications are first going to SNS and then routing to SQS for Oxbow
+
+
+|===

--- a/lambdas/oxbow/src/main.rs
+++ b/lambdas/oxbow/src/main.rs
@@ -34,7 +34,10 @@ async fn main() -> Result<(), anyhow::Error> {
 
 async fn func<'a>(event: LambdaEvent<SqsEvent>) -> Result<Value, Error> {
     debug!("Receiving event: {:?}", event);
-    let records = s3_from_sqs(event.payload)?;
+    let records = match std::env::var("UNWRAP_SNS_ENVELOPE") {
+        Ok(_) => s3_from_sns(event.payload)?,
+        Err(_) => s3_from_sqs(event.payload)?,
+    };
     debug!("processing records: {records:?}");
     let records = records_with_url_decoded_keys(&records);
     let by_table = objects_by_table(&records);


### PR DESCRIPTION
In essence the Oxbow and Auto-tag lambda should still be triggered by SQS, but in order to allow them to rely on the same exact bucket notifications an SNS topic must be configured upstream.

        S3 Event Notifications -> SNS -> Oxbow SQS -> Oxbow
                                   `---> Auto tag SQS -> Auto tag