### PR TITLE
Fix list timestamp coercion

### DIFF
--- a/crates/oxbow/src/lib.rs
+++ b/crates/oxbow/src/lib.rs
@@ -472,10 +472,11 @@ fn coerce_field(
             }
             _ => {}
         },
-        DataType::List(field) => {
-            let coerced = coerce_field(field.clone());
-            let list_field = Field::new(field.name(), DataType::List(coerced), field.is_nullable());
-            return Arc::new(list_field);
+        DataType::List(list_field) => {
+            let coerced = coerce_field(list_field.clone());
+            let coerced_field =
+                Field::new(field.name(), DataType::List(coerced), field.is_nullable());
+            return Arc::new(coerced_field);
         }
         DataType::Struct(fields) => {
             let coerced: Vec<deltalake::arrow::datatypes::FieldRef> =


### PR DESCRIPTION
`field` variable was shadowed to what's inside the list, as the result, the top level element was named `array_element`, not the original name of the field